### PR TITLE
🦄 refactor: 사진 업로드 용량 제한 상수제어

### DIFF
--- a/src/pages/community/BoardWrite.tsx
+++ b/src/pages/community/BoardWrite.tsx
@@ -9,7 +9,7 @@ import { callBoardRegistAPI } from "apis/BoardAPICalls";
 const LIMIT_TITLE_LENGTH = 100;
 const LIMIT_CONTENT_LENGTH = 1000;
 const LIMIT_PHOTO_AMOUNT = 10;
-const LIMIT_PHOTO_SIZE = 10 * 1024 * 1024;
+const LIMIT_PHOTO_SIZE = 64 * 1024 * 1024;
 
 const BoardWrite = (): JSX.Element => {
     const dispatch = useDispatch();
@@ -30,7 +30,6 @@ const BoardWrite = (): JSX.Element => {
     });
     const [images, setImages] = useState<File[]>([]);
     const [urls, setUrls] = useState<string[]>([]);
-    const [currSize, setCurrSize] = useState<number[]>([]);
     const [warnTitle, setWarnTitle] = useState(false);
     const [warnContent, setWarnContent] = useState(false);
     //console.log(`urls : ${urls.length}`);


### PR DESCRIPTION
업로드 가능한 사진의 용량을 상수 하나로 관리할 수 있게 되었습니다.
규모가 커지면 멤버십을 통해 사진 용량을 올릴 수 있는 등의 아이디어를 접목시킬 수 있을 것으로 보입니다.