### PR TITLE
✨ feat: 답글 달기 컴포넌트 추가

### DIFF
--- a/src/components/community/CommentDetail.tsx
+++ b/src/components/community/CommentDetail.tsx
@@ -38,7 +38,7 @@ const CommentDetail = ({ boardCode }: DetailProps) => {
                                 idx > 0 &&
                                 <div className='detail-line'/>
                             }
-                            <CommentItem item={item}/>
+                            <CommentItem item={item} idx={idx} updateIndex={updateIndex} setUpdateIndex={setUpdateIndex}/>
                             {
                                 updateIndex === idx &&
                                 <>

--- a/src/components/community/CommentItem.tsx
+++ b/src/components/community/CommentItem.tsx
@@ -4,10 +4,13 @@ import { useDispatch } from "react-redux";
 import { callRegistCommentAPI } from 'apis/CommunityAPICalls';
 
 type ItemProps = {
-    item: CommentType
+    item: CommentType,
+    idx: number,
+    updateIndex: number,
+    setUpdateIndex: React.Dispatch<React.SetStateAction<number>>
 }
 
-const CommentItem = ({item}: ItemProps): JSX.Element => {
+const CommentItem = ({item, idx, updateIndex, setUpdateIndex}: ItemProps): JSX.Element => {
     const dispatch = useDispatch();
     const getDisplayValue = (timeParam: number): string => {
         timeParam = ~~(timeParam/1000);
@@ -31,6 +34,10 @@ const CommentItem = ({item}: ItemProps): JSX.Element => {
     //     }))
     //     .then(alert('게시글이 삭제되었습니다.'));
     // }
+
+    function onCommentClickHandler(): void {
+        setUpdateIndex(updateIndex === -1 ? idx : -1);
+    }
     return (
         <div className="comment-list-block">
             <div className="comment-owner-block community-drag-none">
@@ -40,7 +47,7 @@ const CommentItem = ({item}: ItemProps): JSX.Element => {
                 </div>
                 <p className="detail-text-info">{uptimeDisplay === 'default' ?
                              `${item.uptime?.substring(2, 10)} ${item.uptime?.substring(11, 16)}` : uptimeDisplay}</p>
-                <div className="comment-btn">
+                <div className="comment-btn" onClick={onCommentClickHandler}>
                     <p>답글 달기</p>
                 </div>
                 {


### PR DESCRIPTION
답글 달기의 컴포넌트를 추가했습니다.
"답글 달기" 버튼을 눌러 답글 컴포넌트를 열고, 다시 클릭하여 닫을 수 있습니다.
또한 최대 1개만 열 수 있기 때문에 다른 댓글의 답글 달기 버튼 클릭 시 기존의 답글 컴포넌트는 더 이상 뜨지 않고, 다른 댓글의 하단에 답글 컴포넌트가 추가됩니다.