### PR TITLE
🐞 fix: 줄바꿈 관련 버그 수정

### DIFF
--- a/src/styles/Community.css
+++ b/src/styles/Community.css
@@ -804,4 +804,5 @@
     font-size: 16px;
     line-height: 23px;
     white-space: pre-line;
+    word-wrap: break-word;
 }


### PR DESCRIPTION
공백과 같은 구분자 없이 문자를 계속해서 나열하면(예: 111111111...) 줄바꿈이 되지 않고 화면 옆으로 텍스트가 나가는 현상을 수정했습니다.